### PR TITLE
Changes to use node-notifier directly.

### DIFF
--- a/app/templates/_gulpfile.js
+++ b/app/templates/_gulpfile.js
@@ -5,6 +5,7 @@ var del = require('del');
 var glob = require('glob');
 var paths = require('./gulp.config.json');
 var plug = require('gulp-load-plugins')();
+var notifier = require('node-notifier');
 var reload = browserSync.reload;
 
 var colors = plug.util.colors;
@@ -147,11 +148,10 @@ gulp.task('build', ['inject-and-rev', 'images', 'fonts'], function() {
     // clean out the temp folder when done
     del(paths.temp);
 
-    return gulp
-        .src('').pipe(plug.notify({
-            onLast: true,
-            message: 'Deployed code!'
-        }));
+    notifier.notify({
+      'title': 'Deployed code!',
+      'message': 'Code as been built, concatonated and minified!'
+    });
 });
 
 /**

--- a/app/templates/_package.json
+++ b/app/templates/_package.json
@@ -40,7 +40,7 @@
     "gulp-minify-html": "^0.1.5",
     "gulp-ng-annotate": "^0.3.2",
     "gulp-nodemon": "^1.0.4",
-    "gulp-notify": "^2.0.1",
+    "node-notifier": "^4.0.3",
     "gulp-plumber": "^0.6.4",
     "gulp-print": "^1.1.0",
     "gulp-rev": "^2.0.1",


### PR DESCRIPTION
I saw you were using the `gulp-notify` on an "empty" stream from gulp. I don't think there is much need to have the overhead of creating a stream with the base folder in order to do the notification. Instead, you can use [node-notifier](https://github.com/mikaelbr/node-notifier) directly (which `gulp-notify` uses internally).

The one drawback of doing it this way, is that it won't have the gulp-notify defaults with a Gulp logo as icon.
