### PR TITLE
Fixed README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ Create an Angular application using the HotTowel style (via a [Yeoman](http://ye
 3. Install these NPM packages globally
 
     ```bash
-    npm install -g bower gulp nodemon`
+    npm install -g bower gulp nodemon
     ```
 
     >Refer to these [instructions on how to not require sudo](https://github.com/sindresorhus/guides/blob/master/npm-global-without-sudo.md)


### PR DESCRIPTION
Removed trailing ` from **npm install -g bower gulp nodemon** instruction.
