### PR TITLE
Fixed top nav image src

### DIFF
--- a/app/templates/src/client/app/layout/ht-top-nav.html
+++ b/app/templates/src/client/app/layout/ht-top-nav.html
@@ -17,12 +17,12 @@
                 </li>
                 <li class="dropdown dropdown-big">
                     <a href="http://www.angularjs.org" target="_blank">
-                        <img src="content/images/AngularJS-small.png" />
+                        <img src="images/AngularJS-small.png" />
                     </a>
                 </li>
                 <li>
                     <a href="http://www.gulpjs.com/" target="_blank">
-                        <img src="content/images/gulp-tiny.png" />
+                        <img src="images/gulp-tiny.png" />
                     </a>
                 </li>
             </ul>


### PR DESCRIPTION
The images currently refer to an 'images' folder within a 'content' folder, that does not exist, so I replaced it by directly referring the 'images' folder.
