### PR TITLE
Corrected typo in _specs.html

### DIFF
--- a/app/templates/src/client/_specs.html
+++ b/app/templates/src/client/_specs.html
@@ -15,7 +15,7 @@
 
     <!--BEWARE of using any app styles as @media can screw up tests -->
 
-    <link rel="stylesheet" href="node_modules/mocha/mocha.css">
+    <link rel="stylesheet" href="/node_modules/mocha/mocha.css">
 
 </head>
 <body>


### PR DESCRIPTION
Thanks for making this generator and code example.
I found a little typo...
A missing forward slash was preventing mocha.css from correctly loading