### PR TITLE
Update gulp-ng-annotate to v0.5.2

### DIFF
--- a/app/templates/_package.json
+++ b/app/templates/_package.json
@@ -40,7 +40,7 @@
     "gulp-less": "^3.0.1",
     "gulp-load-plugins": "^0.7.0",
     "gulp-minify-html": "^0.1.7",
-    "gulp-ng-annotate": "^0.3.2",
+    "gulp-ng-annotate": "^0.5.2",
     "gulp-nodemon": "^1.0.4",
     "gulp-order": "^1.1.1",
     "gulp-plumber": "^0.6.6",


### PR DESCRIPTION
Had to update gulp-ng-annotate to the latest version.

It was blowing up during the build task.