### PR TITLE
set options to disable nodemon stdin listener

### DIFF
--- a/app/templates/_gulpfile.js
+++ b/app/templates/_gulpfile.js
@@ -467,7 +467,9 @@ function getNodeOptions(isDev) {
             'PORT': port,
             'NODE_ENV': isDev ? 'dev' : 'build'
         },
-        watch: [config.server]
+        watch: [config.server],
+        stdin: false,
+        restartable: false
     };
 }
 


### PR DESCRIPTION
When running using the VS2013 Task Runner Extension there is no stdin channel to listen on so nodemon crashes out. Setting these options will allow it to work.
