### PR TITLE
Update to _data.js

### DIFF
--- a/app/templates/src/server/_data.js
+++ b/app/templates/src/server/_data.js
@@ -1,5 +1,5 @@
 module.exports = {
-        people: getPeople()
+    people: getPeople()
 };
 
 function getPeople() {


### PR DESCRIPTION
When you run a gulp build, there is an error on the number of tabs in front of the people. Replacing the 2 tabs with 4 spaces allows the build to go through without failure.