### PR TITLE
Removed redundant disallowMultipleLineStrings declaration

### DIFF
--- a/app/templates/jscsrc
+++ b/app/templates/jscsrc
@@ -63,7 +63,6 @@
     "disallowCommaBeforeLineBreak": null,
     "disallowDanglingUnderscores": null,
     "disallowEmptyBlocks": null,
-    "disallowMultipleLineStrings": null,
     "disallowTrailingComma": null,
     "requireCommaBeforeLineBreak": null,
     "requireDotNotation": null,


### PR DESCRIPTION
Exact same change as in: https://github.com/johnpapa/angular-styleguide/issues/397