### PR TITLE
Upgrade PhantomJS (errors when using io.js)

### DIFF
--- a/app/templates/_package.json
+++ b/app/templates/_package.json
@@ -70,7 +70,7 @@
     "mocha": "^1.20.1",
     "mocha-clean": "^0.4.0",
     "node-notifier": "^4.0.3",
-    "phantomjs": "1.9.9",
+    "phantomjs": "1.9.16",
     "plato": "^1.2.0",
     "q": "^1.0.1",
     "sinon": "^1.12.2",


### PR DESCRIPTION
Upgrade PhantomJS as earlier versions had problems with when running on io.js (see: https://github.com/Medium/phantomjs/issues/275)