### PR TITLE
Upgrade gulp-ng-annotate 

### DIFF
--- a/app/templates/_package.json
+++ b/app/templates/_package.json
@@ -40,7 +40,7 @@
     "gulp-less": "^3.0.1",
     "gulp-load-plugins": "^0.7.0",
     "gulp-minify-html": "^0.1.7",
-    "gulp-ng-annotate": "^0.5.2",
+    "gulp-ng-annotate": "^0.5.3",
     "gulp-nodemon": "^1.0.4",
     "gulp-order": "^1.1.1",
     "gulp-plumber": "^0.6.6",


### PR DESCRIPTION
Upgrade `gulp-ng-annotate` as earlier versions had errors when running `gulp build`. See also https://github.com/johnpapa/generator-hottowel/issues/73