### PR TITLE
Switch from gulp-csso to gulp-minify-css

### DIFF
--- a/app/templates/_gulpfile.js
+++ b/app/templates/_gulpfile.js
@@ -227,7 +227,7 @@ gulp.task('optimize', ['inject', 'test'], function() {
         .pipe(assets) // Gather all assets from the html with useref
         // Get the css
         .pipe(cssFilter)
-        .pipe($.csso())
+        .pipe($.minifyCss())
         .pipe(cssFilter.restore())
         // Get the custom javascript
         .pipe(jsAppFilter)

--- a/app/templates/_package.json
+++ b/app/templates/_package.json
@@ -29,7 +29,7 @@
     "gulp-bump": "^0.1.11",
     "gulp-bytediff": "^0.2.0",
     "gulp-concat": "^2.3.3",
-    "gulp-csso": "^0.2.9",
+    "gulp-minify-css": "^1.1.1",
     "gulp-filter": "^1.0.2",
     "gulp-header": "^1.2.2",
     "gulp-if": "^1.2.5",


### PR DESCRIPTION
This resolves #88: switching from gulp-csso to gulp-minify-css as css has some bugs and seems is no longer being maintained.