### PR TITLE
fix templatecache options 'standalone'

### DIFF
--- a/app/templates/_gulp.config.js
+++ b/app/templates/_gulp.config.js
@@ -80,7 +80,7 @@ module.exports = function() {
             options: {
                 module: 'app.core',
                 root: 'app/',
-                standAlone: false
+                standalone: false
             }
         },
 


### PR DESCRIPTION
Option for template cache is 'standalone', not 'standAlone'
https://github.com/miickel/gulp-angular-templatecache