### PR TITLE
Update _bower.json to include bootstrap.js

### DIFF
--- a/app/templates/_bower.json
+++ b/app/templates/_bower.json
@@ -33,8 +33,10 @@
     },
     "overrides": {
         "bootstrap": {
-            "main": "dist/css/bootstrap.css",
-            "dist": "dist/js/bootstrap.js"
+            "main": [
+                "dist/css/bootstrap.css",
+                "dist/js/bootstrap.js"
+            ]
         }
     }
 }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "generator-hottowel",
-  "version": "0.3.7",
+  "version": "0.3.8",
   "description": "Yeoman generator for HotTowel Angular",
   "license": "MIT",
   "main": "app/index.js",


### PR DESCRIPTION
I don't believe the "dist" property is used anymore, however, I do believe the intention here is to include bootstrap.js by default. 

I have updated the bootstrap override to include bootstrap.js when running the gulp task.