### PR TITLE
limit angular to 1.4.x - until compatible with 1.5.x

### DIFF
--- a/app/templates/_bower.json
+++ b/app/templates/_bower.json
@@ -12,21 +12,21 @@
         "tests"
     ],
     "devDependencies": {
-        "angular-mocks": "^1.4.5",
+        "angular-mocks": "~1.4.5",
         "sinon": "http://sinonjs.org/releases/sinon-1.12.1.js",
         "bardjs": "^0.1.4"
     },
     "dependencies": {
         "jquery": "^2.1.4",
-        "angular": "^1.4.5",
-        "angular-sanitize": "^1.4.5",
+        "angular": "~1.4.5",
+        "angular-sanitize": "~1.4.5",
         "bootstrap": "^3.3.5",
         "extras.angular.plus": "^0.9.2",
         "font-awesome": "^4.3.0",
         "moment": "^2.10.3",
         "angular-ui-router": "^0.2.15",
         "toastr": "^2.1.1",
-        "angular-animate": "^1.4.5"
+        "angular-animate": "~1.4.5"
     },
     "resolutions": {
         "angular": "1.3.17"


### PR DESCRIPTION
Hi, I just tried this project but unfortunately it is broken out of the box. Details in https://github.com/johnpapa/generator-hottowel/issues/154. It doesn't seem to be happy with Angular 1.5.

Until you can bring it up to date, here is a trivial PR that will restrict it to Angular 1.4.x. This solution was from https://github.com/kmorey. This makes it build fine for me, although I've not done any more serious testing.

Hope that helps,
James