### PR TITLE
Moved logger reporting before $delegate

### DIFF
--- a/app/templates/src/client/app/blocks/exception/exception-handler.provider.js
+++ b/app/templates/src/client/app/blocks/exception/exception-handler.provider.js
@@ -52,7 +52,6 @@
       var appErrorPrefix = exceptionHandler.config.appErrorPrefix || '';
       var errorData = { exception: exception, cause: cause };
       exception.message = appErrorPrefix + exception.message;
-      $delegate(exception, cause);
       /**
        * Could add the error to a service's collection,
        * add errors to $rootScope, log errors to remote web server,
@@ -63,6 +62,8 @@
        *     throw { message: 'error message we added' };
        */
       logger.error(exception.message, errorData);
+      
+      $delegate(exception, cause);
     };
   }
 })();


### PR DESCRIPTION
Report of the error was moved before $delegate so that it can be tested. I could not write a PR for the test also, because I am not comfortable with Mocha and Chai but the general idea is that we could test it by adding something like the following snippet in [here](https://github.com/johnpapa/generator-hottowel/blob/master/app/templates/src/client/app/blocks/exception/exception-handler.provider.spec.js#L61):

    expect(logger.error).toHaveBeenCalledWith(ex.message, { 
      exception: new Error(mocks.prefix + mocks.errorMessage), cause: undefined 
    });