### PR TITLE
Mitigate against reflected XSS attacks

### DIFF
--- a/app/templates/src/server/_app.js
+++ b/app/templates/src/server/_app.js
@@ -30,6 +30,17 @@ switch (environment) {
     app.use('/app/*', function(req, res, next) {
       four0four.send404(req, res);
     });
+    // Invalid calls to assets should return the custom error object to mitigate 
+    // against XSS reflected attacks
+    app.use('/js/*', function(req, res, next) {
+        four0four.send404(req, res);
+    });
+    app.use('/images/*', function(req, res, next) {
+        four0four.send404(req, res);
+    });
+    app.use('/styles/*', function(req, res, next) {
+        four0four.send404(req, res);
+    });
     // Any deep link calls should return index.html
     app.use('/*', express.static('./build/index.html'));
     break;


### PR DESCRIPTION
Mitigate against reflected XSS attacks in production by returning
the custom 404 response object instead of express' default 404
response

A reflected XSS vulnerability was discovered using the Burp pen test tool and successfully tested
by passing an arbitrary url parameter GET /images/?41b68(a)184a9=1

This input was echoed unmodified in the application's response meaning that it is possible to inject JavaScript commands into the returned document

This fixes #132 
