### PR TITLE
Feature / e2e Protractor

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,6 +60,23 @@ Create an Angular application using the HotTowel style (via a [Yeoman](http://ye
 ### Tests
  - Run the unit tests using `gulp test` (via karma, mocha, sinon).
 
+### E2E Tests
+ - Run e2e unit tests using `gulp test-e2e` (via protractor).
+ - Make sure that the server is running with either `gulp serve-build` or 
+`gulp serve-dev` in a separate terminal prior to running `gulp test-e2e`.
+
+ - Example
+
+  Bash Terminal 1
+    ```bash
+    gulp serve-dev
+    ```
+
+  Bash Terminal 2
+    ```bash
+    gulp test-e2e
+    ```
+
 ### Running in dev mode
  - Run the project with `gulp serve-dev`
 

--- a/app/index.js
+++ b/app/index.js
@@ -60,6 +60,7 @@ var HotTowelGenerator = yeoman.Base.extend({
     this.template('_bower.json', 'bower.json');
     this.template('_gulpfile.js', 'gulpfile.js');
     this.template('_gulp.config.js', 'gulp.config.js');
+    this.template('_protractor.config.js', 'protractor.config.js');
     this.template('_karma.conf.js', 'karma.conf.js');
     this.template('_README.md', 'README.md');
   },
@@ -76,6 +77,7 @@ var HotTowelGenerator = yeoman.Base.extend({
     this.directory('src/client/app');
     this.directory('src/client/images');
     this.directory('src/client/styles');
+    this.directory('src/client/test');
     this.directory('src/client/test-helpers');
 
     this.template('src/client/_index.html', 'src/client/index.html');

--- a/app/templates/_README.md
+++ b/app/templates/_README.md
@@ -46,6 +46,7 @@
     ```bash
     gulp test-e2e
     ```
+
 ### Running in dev mode
  - Run the project with `gulp serve-dev`
 

--- a/app/templates/_README.md
+++ b/app/templates/_README.md
@@ -30,6 +30,22 @@
 ### Tests
  - Run the unit tests using `gulp test` (via karma, mocha, sinon).
 
+### E2E Tests
+ - Run e2e unit tests using `gulp test-e2e` (via protractor).
+ - Make sure that the server is running with either `gulp serve-build` or 
+`gulp serve-dev` in a separate terminal prior to running `gulp test-e2e`.
+
+ - Example
+
+  Bash Terminal 1
+    ```bash
+    gulp serve-dev
+    ```
+
+  Bash Terminal 2
+    ```bash
+    gulp test-e2e
+    ```
 ### Running in dev mode
  - Run the project with `gulp serve-dev`
 

--- a/app/templates/_gulp.config.js
+++ b/app/templates/_gulp.config.js
@@ -117,6 +117,10 @@ module.exports = function() {
     specHelpers: [client + 'test-helpers/*.js'],
     specs: [clientApp + '**/*.spec.js'],
     serverIntegrationSpecs: [client + '/tests/server-integration/**/*.spec.js'],
+    /**
+     * E2E Scenario Files
+     */
+    scenarios: client + '/test/e2e/**/*.spec.js',
 
     /**
      * Node settings

--- a/app/templates/_package.json
+++ b/app/templates/_package.json
@@ -5,6 +5,7 @@
   "scripts": {
     "init": "npm install",
     "install": "bower install",
+    "postinstall": "webdriver-manager update",
     "start": "node src/server/app.js",
     "test": "gulp test"
   },
@@ -45,6 +46,7 @@
     "gulp-order": "^1.1.1",
     "gulp-plumber": "^1.0.1",
     "gulp-print": "^1.1.0",
+    "gulp-protractor": "^2.3.0",
     "gulp-rev": "^5.1.0",
     "gulp-rev-replace": "^0.4.2",
     "gulp-sourcemaps": "^1.1.5",

--- a/app/templates/_protractor.config.js
+++ b/app/templates/_protractor.config.js
@@ -1,0 +1,6 @@
+var gulpConfig = require('./gulp.config')();
+
+exports.config = {
+  baseUrl: 'http://localhost:' + gulpConfig.defaultPort,
+  specs: gulpConfig.scenarios
+};

--- a/app/templates/src/client/app/blocks/exception/exception-handler.provider.js
+++ b/app/templates/src/client/app/blocks/exception/exception-handler.provider.js
@@ -62,7 +62,7 @@
        *     throw { message: 'error message we added' };
        */
       logger.error(exception.message, errorData);
-      
+
       $delegate(exception, cause);
     };
   }

--- a/app/templates/src/client/test/e2e/dashboard/dashboard.spec.js
+++ b/app/templates/src/client/test/e2e/dashboard/dashboard.spec.js
@@ -1,0 +1,15 @@
+/* jshint -W117 */
+describe('E2E: Dashboard', function () {
+  beforeEach(function() {
+    browser.get('/');
+  });
+
+  it('should have dashboard in its <title> tag.', function() {
+    expect(browser.getTitle()).toContain('dashboard');
+  });
+
+  it('should have home button active', function() {
+    var curNav = element(by.css('.current')).$('a');
+    expect(curNav.getText()).toBe('Dashboard');
+  });
+});

--- a/app/templates/src/client/test/e2e/sidebar/sidebar.spec.js
+++ b/app/templates/src/client/test/e2e/sidebar/sidebar.spec.js
@@ -1,0 +1,40 @@
+/* jshint -W117 */
+describe('E2E: Navigation > Sidebar', function() {
+  var sidebarLinks;
+
+  beforeEach(function() {
+    // in most cases, want to start at the root page
+    browser.get('/');
+  });
+
+  beforeEach(function() {
+    sidebarLinks = element.all(by.repeater('r in vm.navRoutes'));
+  });
+
+  it('should have sidebar configured properly', function() {
+    expect(sidebarLinks.count()).toBe(2);
+    expect(sidebarLinks.get(0).getText()).toBe('Dashboard');
+    expect(sidebarLinks.get(1).getText()).toBe('Admin');
+  });
+
+  it('should have sidebar navigate to admin', function(done) {
+    sidebarLinks.get(1).click().then(function() {
+      expect(browser.getTitle()).toContain('Admin');
+      expect(browser.getCurrentUrl()).toContain('admin');
+      expect(element(by.css('.current')).$('a').getText()).toBe('Admin');
+    }).thenFinally(function() {
+      done();
+    });
+  });
+
+  it('should navigate to dashboard', function(done) {
+    browser.get('/admin');
+
+    sidebarLinks.get(0).click().then(function() {
+      expect(browser.getTitle()).toContain('dashboard');
+      expect(element(by.css('.current')).$('a').getText()).toBe('Dashboard');
+    }).thenFinally(function() {
+      done();
+    });
+  });
+});


### PR DESCRIPTION
Added protractor e2e testing to the current version of hottowel. Heavily influenced by PR #49. Thanks @sryzycki for the base code to work from.

I put e2e tests in client/test/e2e since e2e tests can be comprised of dealing with interactions with different modules, and so the spec files are not included when injecting spec files for karma or spec.html.

Also, I added basic e2e testing with navigating with the sidebar mostly just as an example of dealing with selectors, button click operations, and promises. I didn't add too many example tests to kind of keep simple and to the point, but enough to give others some insight on how to work with protractor using the example app provided.

This is my first time dealing with e2e and protractor, so any suggestions are appreciated.
