### PR TITLE
fix 'gulp serve-specs'

### DIFF
--- a/app/templates/_gulp.config.js
+++ b/app/templates/_gulp.config.js
@@ -112,6 +112,7 @@ module.exports = function() {
     testlibraries: [
       nodeModules + '/mocha/mocha.js',
       nodeModules + '/chai/chai.js',
+      nodeModules + '/sinon/pkg/sinon.js',
       nodeModules + '/sinon-chai/lib/sinon-chai.js'
     ],
     specHelpers: [client + 'test-helpers/*.js'],


### PR DESCRIPTION
add builded sinon.js for specs run in browser